### PR TITLE
Remove gurobipy license file from conda downloads

### DIFF
--- a/src/wrappers/aarch64-apple-darwin.jl
+++ b/src/wrappers/aarch64-apple-darwin.jl
@@ -3,6 +3,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+using Artifacts
+
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -22,6 +24,7 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
+    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/aarch64-apple-darwin.jl
+++ b/src/wrappers/aarch64-apple-darwin.jl
@@ -3,8 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using Artifacts
-
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -24,7 +22,10 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
+    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
+    if isfile(gurobi_lic)
+        rm(gurobi_lic; force = true)
+    end
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-apple-darwin.jl
+++ b/src/wrappers/x86_64-apple-darwin.jl
@@ -3,6 +3,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+using Artifacts
+
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -22,6 +24,7 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
+    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-apple-darwin.jl
+++ b/src/wrappers/x86_64-apple-darwin.jl
@@ -3,8 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using Artifacts
-
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -24,7 +22,10 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
+    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
+    if isfile(gurobi_lic)
+        rm(gurobi_lic; force = true)
+    end
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-linux-gnu.jl
+++ b/src/wrappers/x86_64-linux-gnu.jl
@@ -3,6 +3,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+using Artifacts
+
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -22,6 +24,7 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
+    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-linux-gnu.jl
+++ b/src/wrappers/x86_64-linux-gnu.jl
@@ -3,8 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using Artifacts
-
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -24,7 +22,10 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
     JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    rm(joinpath(artifact"Gurobi", "lib/gurobi.lic"), force=true)
+    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
+    if isfile(gurobi_lic)
+        rm(gurobi_lic; force = true)
+    end
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-w64-mingw32.jl
+++ b/src/wrappers/x86_64-w64-mingw32.jl
@@ -3,8 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using Artifacts
-
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -26,7 +24,10 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "gurobi_cl.exe")
     JLLWrappers.@init_executable_product(grbgetkey, "grbgetkey.exe")
-    rm(joinpath(artifact"Gurobi", "gurobi.lic"), force=true)
+    gurobi_lic = joinpath(artifact_dir, "gurobi.lic")
+    if isfile(gurobi_lic)
+        rm(gurobi_lic; force = true)
+    end
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-w64-mingw32.jl
+++ b/src/wrappers/x86_64-w64-mingw32.jl
@@ -3,6 +3,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+using Artifacts
+
 export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
@@ -24,6 +26,7 @@ function __init__()
     )
     JLLWrappers.@init_executable_product(gurobi_cl, "gurobi_cl.exe")
     JLLWrappers.@init_executable_product(grbgetkey, "grbgetkey.exe")
+    rm(joinpath(artifact"Gurobi", "gurobi.lic"), force=true)
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,13 @@ end
 @testset "grbgetkey" begin
     @test Gurobi_jll.grbgetkey_path isa String
 end
+
+@testset "license_error" begin
+    envptr = Ref{Ptr{Cvoid}}()
+    error = @ccall libgurobi.GRBemptyenv(envptr::Ptr{Ptr{Cvoid}})::Cint
+    @test error == 0
+    error = @ccall libgurobi.GRBstartenv(envptr.x::Ptr{Cvoid})::Cint
+    @test error == 10009
+    msg = unsafe_string(@ccall libgurobi.GRBgeterrormsg(envptr.x::Ptr{Cvoid})::Ptr{Cchar})
+    @test startswith(msg, "No Gurobi license found")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,8 +44,8 @@ end
     envptr = Ref{Ptr{Cvoid}}()
     error = @ccall libgurobi.GRBemptyenv(envptr::Ptr{Ptr{Cvoid}})::Cint
     @test error == 0
-    error = @ccall libgurobi.GRBstartenv(envptr.x::Ptr{Cvoid})::Cint
+    error = @ccall libgurobi.GRBstartenv(envptr[]::Ptr{Cvoid})::Cint
     @test error == 10009
-    msg = unsafe_string(@ccall libgurobi.GRBgeterrormsg(envptr.x::Ptr{Cvoid})::Ptr{Cchar})
+    msg = unsafe_string(@ccall libgurobi.GRBgeterrormsg(envptr[]::Ptr{Cvoid})::Ptr{Cchar})
     @test startswith(msg, "No Gurobi license found")
 end


### PR DESCRIPTION
The conda packages include a license file which will only work from Python. So currently, if the user does not have a Gurobi license on their machine, they'll get a confusing error message:

```
PIP license can only be used from gurobipy interface
```

This PR is to delete the license file in the extracted artifact dir so that we get a more sensible message:

```
No Gurobi license found
```