### PR TITLE
Use the full Gurobi packages for artifacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,40 +1,40 @@
 [[Gurobi]]
-git-tree-sha1 = "11980007f4c80fcdcbdd8e7b8dafaa8657dcead9"
+git-tree-sha1 = "f0e5f5a89f78144698ed87413adc7743688584f5"
 arch = "x86_64"
 os = "linux"
 
     [[Gurobi.download]]
-    sha256 = "df72e6621633f3bb88faa0fd08daa0c0fa84492b9ab20237e4422f23b3898903"
-    url = "https://anaconda.org/Gurobi/gurobi/12.0.3/download/linux-64/gurobi-12.0.3-py311_0.tar.bz2"
+    sha256 = "98455455709e8b34b34032ed90d4bf1246b14f4313a312f7c775066ff5c1f652"
+    url = "https://packages.gurobi.com/13.0/gurobi13.0.0_linux64.tar.gz"
 [[Gurobi]]
-git-tree-sha1 = "9ab677b1a86b74c7561876f064c4924e44e53338"
+git-tree-sha1 = "8c5a6a5a0da6625f88cd6349d26e910ffe670c9f"
 arch = "aarch64"
 os = "linux"
 
     [[Gurobi.download]]
-    sha256 = "26b93fd4ef91ef220d1739a321aba3fd023a206a733849d64f5c1708b8db9a8a"
-    url = "https://anaconda.org/Gurobi/gurobi/12.0.3/download/linux-aarch64/gurobi-12.0.3-py311_0.tar.bz2"
+    sha256 = "d301613332cad505620dcd192ccfe855e9ad456d20f8544944514e2ff7a23851"
+    url = "https://packages.gurobi.com/13.0/gurobi13.0.0_armlinux64.tar.gz"
 [[Gurobi]]
-git-tree-sha1 = "6128cd989db64bbbce58dd5725bb2990b87f18c9"
+git-tree-sha1 = "df29ce14d0a4a14d0ab2ad6233c0c6a9bb76abce"
 arch = "x86_64"
 os = "macos"
 
     [[Gurobi.download]]
-    sha256 = "83031cf70526a2d8d5d4d2a500779fea447a3542975401b0ab42dd721de6d447"
-    url = "https://anaconda.org/Gurobi/gurobi/12.0.3/download/osx-64/gurobi-12.0.3-py311_0.tar.bz2"
+    sha256 = "85ac3591eadea53d041fa5b19ba61582c567a43aabfe04e36780c88acf35f36c"
+    url = "https://packages.gurobi.com/13.0/gurobi13.0.0_macos_universal2.tar.gz"
 [[Gurobi]]
-git-tree-sha1 = "49c8e5760716c69803360127c673c65ea56a65f5"
+git-tree-sha1 = "df29ce14d0a4a14d0ab2ad6233c0c6a9bb76abce"
 arch = "aarch64"
 os = "macos"
 
     [[Gurobi.download]]
-    sha256 = "1600598d2cc6fe958ac4e56e32d69266020238ce4c4fa1f2f28c81c94101b33c"
-    url = "https://anaconda.org/Gurobi/gurobi/12.0.3/download/osx-arm64/gurobi-12.0.3-py311_0.tar.bz2"
+    sha256 = "85ac3591eadea53d041fa5b19ba61582c567a43aabfe04e36780c88acf35f36c"
+    url = "https://packages.gurobi.com/13.0/gurobi13.0.0_macos_universal2.tar.gz"
 [[Gurobi]]
-git-tree-sha1 = "b31bf0fecbd28572b2ff8cf05c035350be319a5d"
+git-tree-sha1 = "5880b5e4612ccf8d60680288f5cbeb8d7429f765"
 arch = "x86_64"
 os = "windows"
 
     [[Gurobi.download]]
-    sha256 = "d4a3f481e863b30e994d73ef9aaaf91362d6e99cf5d8aa543b87bc89feba453c"
-    url = "https://anaconda.org/Gurobi/gurobi/12.0.3/download/win-64/gurobi-12.0.3-py311_0.tar.bz2"
+    sha256 = "7ffd782fe8c8576bd5fdcd8c9a12191dca03606384a47193202b06ac95fffdbb"
+    url = "https://packages.gurobi.com/13.0/gurobi13.0.0_win64.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gurobi_jll"
 uuid = "c018c7e6-a5b0-4aea-8f80-9c1ef9991411"
 authors = ["odow <o.dowson@gmail.com>"]
-version = "12.0.3"
+version = "13.0.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `Gurobi_jll.jl`
 
 `Gurobi_jll` is a JLL package manually built from the binaries at
-[https://anaconda.org/Gurobi/gurobi/files](https://anaconda.org/Gurobi/gurobi/files).
+[https://www.gurobi.com/downloads/](https://www.gurobi.com/downloads/).
 
 ## Affiliation
 
@@ -17,9 +17,9 @@ The Gurobi artifacts that are automatically downloaded on install are governed
 by the [Gurobi EULA](https://www.gurobi.com/EULA). When installing `Gurobi_jll`,
 you accept the terms of this agreement.
 
-A copy of the license agreement is stored at `share/doc/gurobi/EULA.pdf` in the
+A copy of the license agreement is stored at `gurobiXYZ/<platform>/EULA.pdf` in the
 installed artifact. Copies of the licenses of third-party software used in the
-Gurobi libraries are provided in `info/licenses/thirdparty` in the installed
+Gurobi libraries are provided in `gurobiXYZ/<platform>/licenses` in the installed
 artifact, which is located at `Gurobi_jll.artifact_dir`.
 
 The underlying solver is a closed-source commercial product for which you must
@@ -32,6 +32,7 @@ The underlying solver is a closed-source commercial product for which you must
 * `macOS x86_64` (`x86_64-apple-darwin`)
 * `macOS arm64` (`aarch64-apple-darwin`)
 * `Linux x86_64` (`x86_64-linux-gnu`)
+* `Linux arm64` (`aarch64-linux-gnu`)
 * `Windows x86_64` (`x86_64-w64-mingw32`)
 
 ## Products

--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -6,10 +6,10 @@ The Gurobi artifacts that are automatically downloaded on install are governed
 by the [Gurobi EULA](https://www.gurobi.com/EULA). When installing `Gurobi_jll`,
 you accept the terms of this agreement.
 
-A copy of the license agreement is stored at `share/doc/gurobi/EULA.pdf` in the
-installed artifact, which is located at `Gurobi_jll.artifact_dir`. Copies of
-the licenses of third-party software used in the Gurobi libraries are provided in
-`share/doc/gurobi/refman/copyright_notices_for_3rd_.html` in the installed artifact.
+A copy of the license agreement is stored at `gurobiXYZ/<platform>/EULA.pdf` in the
+installed artifact. Copies of the licenses of third-party software used in the
+Gurobi libraries are provided in `gurobiXYZ/<platform>/licenses` in the installed
+artifact, which is located at `Gurobi_jll.artifact_dir`.
 
 The underlying solver is a closed-source commercial product for which you must
 [purchase a license](https://www.gurobi.com).

--- a/src/wrappers/aarch64-apple-darwin.jl
+++ b/src/wrappers/aarch64-apple-darwin.jl
@@ -7,7 +7,7 @@ export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
 
-JLLWrappers.@declare_library_product(libgurobi, "@rpath/libgurobi120.dylib")
+JLLWrappers.@declare_library_product(libgurobi, "@rpath/libgurobi130.dylib")
 
 JLLWrappers.@declare_executable_product(gurobi_cl)
 
@@ -17,15 +17,11 @@ function __init__()
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libgurobi,
-        "lib/libgurobi120.dylib",
+        "gurobi1300/macos_universal2/lib/libgurobi130.dylib",
         RTLD_LAZY | RTLD_DEEPBIND,
     )
-    JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
-    JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
-    if isfile(gurobi_lic)
-        rm(gurobi_lic; force = true)
-    end
+    JLLWrappers.@init_executable_product(gurobi_cl, "gurobi1300/macos_universal2/bin/gurobi_cl")
+    JLLWrappers.@init_executable_product(grbgetkey, "gurobi1300/macos_universal2/bin/grbgetkey")
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/aarch64-linux-gnu.jl
+++ b/src/wrappers/aarch64-linux-gnu.jl
@@ -7,7 +7,7 @@ export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
 
-JLLWrappers.@declare_library_product(libgurobi, "libgurobi120.so")
+JLLWrappers.@declare_library_product(libgurobi, "libgurobi130.so")
 
 JLLWrappers.@declare_executable_product(gurobi_cl)
 
@@ -17,15 +17,11 @@ function __init__()
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libgurobi,
-        "lib/libgurobi120.so",
+        "gurobi1300/armlinux64/lib/libgurobi130.so",
         RTLD_LAZY | RTLD_DEEPBIND,
     )
-    JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
-    JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
-    if isfile(gurobi_lic)
-        rm(gurobi_lic; force = true)
-    end
+    JLLWrappers.@init_executable_product(gurobi_cl, "gurobi1300/armlinux64/bin/gurobi_cl")
+    JLLWrappers.@init_executable_product(grbgetkey, "gurobi1300/armlinux64/bin/grbgetkey")
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-apple-darwin.jl
+++ b/src/wrappers/x86_64-apple-darwin.jl
@@ -7,7 +7,7 @@ export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
 
-JLLWrappers.@declare_library_product(libgurobi, "@rpath/libgurobi120.dylib")
+JLLWrappers.@declare_library_product(libgurobi, "@rpath/libgurobi130.dylib")
 
 JLLWrappers.@declare_executable_product(gurobi_cl)
 
@@ -17,21 +17,16 @@ function __init__()
     JLLWrappers.@generate_init_header()
     # This is needed to work-around a permission issue on some intel macs.
     # See Gurobi.jl#545 for details.
-    libgurobi_path = joinpath(artifact_dir, "lib", "libgurobi120.dylib")
+    libgurobi_path = joinpath(artifact_dir, "gurobi1300", "macos_universal2", "lib", "libgurobi130.dylib")
     run(`codesign --remove-signature $libgurobi_path`)
     # Back to the standard header
     JLLWrappers.@init_library_product(
         libgurobi,
-        "lib/libgurobi120.dylib",
+        "gurobi1300/macos_universal2/lib/libgurobi130.dylib",
         RTLD_LAZY | RTLD_DEEPBIND,
     )
-    JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
-    JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    # The standard license supports only Python installs. Remove it.
-    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
-    if isfile(gurobi_lic)
-        rm(gurobi_lic; force = true)
-    end
+    JLLWrappers.@init_executable_product(gurobi_cl, "gurobi1300/macos_universal2/bin/gurobi_cl")
+    JLLWrappers.@init_executable_product(grbgetkey, "gurobi1300/macos_universal2/bin/grbgetkey")
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-linux-gnu.jl
+++ b/src/wrappers/x86_64-linux-gnu.jl
@@ -7,7 +7,7 @@ export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
 
-JLLWrappers.@declare_library_product(libgurobi, "libgurobi120.so")
+JLLWrappers.@declare_library_product(libgurobi, "libgurobi130.so")
 
 JLLWrappers.@declare_executable_product(gurobi_cl)
 
@@ -17,15 +17,11 @@ function __init__()
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libgurobi,
-        "lib/libgurobi120.so",
+        "gurobi1300/linux64/lib/libgurobi130.so",
         RTLD_LAZY | RTLD_DEEPBIND,
     )
-    JLLWrappers.@init_executable_product(gurobi_cl, "bin/gurobi_cl")
-    JLLWrappers.@init_executable_product(grbgetkey, "bin/grbgetkey")
-    gurobi_lic = joinpath(artifact_dir, "lib", "gurobi.lic")
-    if isfile(gurobi_lic)
-        rm(gurobi_lic; force = true)
-    end
+    JLLWrappers.@init_executable_product(gurobi_cl, "gurobi1300/linux64/bin/gurobi_cl")
+    JLLWrappers.@init_executable_product(grbgetkey, "gurobi1300/linux64/bin/grbgetkey")
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/src/wrappers/x86_64-w64-mingw32.jl
+++ b/src/wrappers/x86_64-w64-mingw32.jl
@@ -7,7 +7,7 @@ export gurobi_cl, grbgetkey, libgurobi
 
 JLLWrappers.@generate_wrapper_header("Gurobi")
 
-JLLWrappers.@declare_library_product(libgurobi, "gurobi120.dll")
+JLLWrappers.@declare_library_product(libgurobi, "gurobi130.dll")
 
 JLLWrappers.@declare_executable_product(gurobi_cl)
 
@@ -15,19 +15,13 @@ JLLWrappers.@declare_executable_product(grbgetkey)
 
 function __init__()
     JLLWrappers.@generate_init_header()
-    gurobi_lic = joinpath(artifact_dir, "gurobi.lic")
-    if isfile(gurobi_lic)
-        rm(gurobi_lic; force = true)
-        # While we're at it, there's a permission error with the conda binaries
-        chmod(artifact_dir, 0o755; recursive = true)
-    end
     JLLWrappers.@init_library_product(
         libgurobi,
-        "gurobi120.dll",
+        joinpath("gurobi1300", "win64", "bin", "gurobi130.dll"),
         RTLD_LAZY | RTLD_DEEPBIND,
     )
-    JLLWrappers.@init_executable_product(gurobi_cl, "gurobi_cl.exe")
-    JLLWrappers.@init_executable_product(grbgetkey, "grbgetkey.exe")
+    JLLWrappers.@init_executable_product(gurobi_cl, joinpath("gurobi1300", "win64", "bin", "gurobi_cl.exe"))
+    JLLWrappers.@init_executable_product(grbgetkey, joinpath("gurobi1300", "win64", "bin", "grbgetkey.exe"))
     JLLWrappers.@generate_init_footer()
     return
 end  # __init__()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,9 +20,9 @@ end
         technicalP::Ptr{Cint},
     )::Cvoid
     # Update these values when you update Artifacts.toml
-    @test majorP[] == 12
+    @test majorP[] == 13
     @test minorP[] == 0
-    @test technicalP[] == 3
+    @test technicalP[] == 0
 end
 
 @testset "gurobi_cl" begin


### PR DESCRIPTION
To handle Gurobi 13.0 support (#36). We cannot use the new conda packaging format since julia Artifacts must be tarballs.

The missing piece is we need to publish the macOS tarball as a source. We currently build that internally, but we don't publish it because the binary isn't signed. So a few questions for @odow:
- Is it an issue that the .dylib would be unsigned? I am guessing not, since Gurobi_jll manually removes the signature using `codesign` (but only on Intel Macs, for some reason).
- Is it an issue that both ARM and x86 would use a universal binary for the JLL? I tested this on my mac M3, Julia does not seem to have an issue with it.
- The dylib's ID is set assuming it will go to the installer location (`/Library/gurobi1300/...`) because this is required for .pkg installers on macos. Similarly, `gurobi_cl` is linked to the library there. This seems not to be an issue though, Gurobi.jl picked up the correct dylib in my tests, since it dlopen's a target path. The only oddity is when executing `gurobi_cl` through Julia. It will preference a libgurobi found in `/Library/gurobi...`if it exists, because the JLL binary executor only sets `DYLD_LIBRARY_FALLBACK_PATH`. We could rewrite the IDs and rpaths of the libraries and binaries in the wrapper scripts, but I'm not sure it's really needed.

My other issue: I have never managed to get the `update_artifacts.jl` script to get the correct tree SHA1. I always have to update the hashes manually after the CI tests fail. Seems the whole setup is acknowledged as pretty unstable:

https://github.com/JuliaLang/Pkg.jl/blob/1e90f07f9f28e9cec60c5aea0e55302a02164b10/src/Artifacts.jl#L379-L382

I guess my point is, do we need a test for ARMlinux to make sure that hash is correct?